### PR TITLE
Fix About Us Section Issues

### DIFF
--- a/docs/about/about.md
+++ b/docs/about/about.md
@@ -4,17 +4,17 @@ title: About Us
 custom_edit_url: null
 ---
 
-Open Source with SLU was established to help SLU researchers with their custom software needs and to give students practical software development experience. The program is funded by a grant from Alfred P. Sloan foundation and employs Computer Science graduate students to prototype, design, and deliver open-source software to help SLU researchers and their collaborators worldwide. Undergraduate students enrolled in project-based courses work with Open Source with SLU under the mentorship of our graduate students to contribute to ongoing open source projects.
+Open Source with SLU was established to help SLU researchers with their custom software needs, and to give students practical software development experience. The program is funded by a grant from the Alfred P. Sloan Foundation, and employs Computer Science graduate students to prototype, design, and deliver open-source software to help SLU researchers and their collaborators worldwide. Undergraduate students enrolled in project-based courses work with Open Source with SLU under the mentorship of our graduate students to contribute to ongoing open source projects.
 
 ## Leadership Team
 
 ### Daniel Shown
 
-Daniel Shown is the Program Director of the Open Source with SLU program. He handles the program's daily operations, builds connections with industry partners, works with internal and external clients of the program, guides and supports our graduate students. Daniel's focus is to ensure that the program follows its mission of research support, commitment to open-source, and providing students with relevant software development experience.
+Daniel Shown is the Program Director of the Open Source with SLU program. He handles the program's daily operations, builds connections with industry partners, works with internal and external clients of the program, and guides and supports our graduate students. Daniel's focus is to ensure that the program follows its mission of research support, commitment to open-source, and providing students with relevant software development experience.
 
 ### Kate Holdener, Ph.D.
 
-Kate Holdener is an Assistant Professor of Computer Science at Saint Louis University. Her main focus in the department is on software engineering courses. She founded the open-source software program in an effort to engage more student in open-source development, as a way to give them practical experience during school.
+Kate Holdener is an Assistant Professor of Computer Science at Saint Louis University. Her main focus in the department is on software engineering courses. She founded the open-source software program in an effort to engage more students in open-source development, as a way to give them practical experience during school.
 
 ## Graduate Students
 
@@ -23,10 +23,11 @@ Graduate students are at the heart of our open-sour​ce program. They work with
 ### Current Graduate Assistant Team Leads
 
 - Abhilash Kotha
+- Logan Wyas
 - Ruthvik Mannem
 - Sailikhita Pulijala
 - Yash Kamal Bhatia
-- Yashaswini shivalingaiah
+- Yashaswini Shivalingaiah
 
 ### Previous Graduate Assistant Team Leads
 
@@ -37,12 +38,12 @@ Graduate students are at the heart of our open-sour​ce program. They work with
 
 ## SLU Research Team Leads
 
-Staff from Saint Louis University's Research Computing Group have been key partners, and have even taken on the responsibility of leading teams of undergraduate students.  Their work includes active open source projects being used in academia and research.  Projects involve SLU researchers across campus, regional organizations such as the Taylor Geospatial Institute, Washington University in Saint Louis, Newberry Library, the Jesuit Archives, Missouri Botanical Garden, and the St. Louis Federal Reserve. They are also involved in international open standards groups such as the International Image Interoperability Framework (IIIF) and Open Geospatial Consortium (OGC). This team supports the popular public tools TPEN ([t-pen.org](https://t-pen.org)) and the Rerum ecosystem ([rerum.io](https://rerum.io)).
+Staff from Saint Louis University's Research Computing Group have been key partners, and have even taken on the responsibility of leading teams of undergraduate students. Their work includes active open-source projects being used in academia and research. Projects involve SLU researchers across campus, regional organizations such as the Taylor Geospatial Institute, Washington University in Saint Louis, Newberry Library, the Jesuit Archives, Missouri Botanical Garden, and the St. Louis Federal Reserve. They are also involved in international open standards groups such as the International Image Interoperability Framework (IIIF) and Open Geospatial Consortium (OGC). This team supports the popular public tools TPEN ([t-pen.org](https://t-pen.org)) and the Rerum ecosystem ([rerum.io](https://rerum.io)).
 
 ### Patrick Cuba
 
-Patrick Cuba is the IT Architect for RCG at SLU. His service is focused on consulting and project development, translating research questions into features and helping to accellerate human-driven research. Specifically, he designs, develops, and implements technological solutions for use cases that escape typical vendor solutions, usually because of requirements for sustainability, openness, or customizable encoding. He has a passion for the record of human knowledge, especially supporting controversy, ambiuguity, and attribution.
+Patrick Cuba is the IT Architect for RCG at SLU. His service is focused on consulting and project development, translating research questions into features, and helping to accelerate human-driven research. Specifically, he designs, develops, and implements technological solutions for use cases that escape typical vendor solutions, usually because of requirements for sustainability, openness, or customizable encoding. He has a passion for the record of human knowledge, especially supporting controversy, ambiguity, and attribution.
 
 ### Bryan Haberberger
 
-Bryan Haberberger is the Full Stack Developer for RCG at SLU.  He works in the technology stacks behind various projects, and his focus shifts sprint by sprint.  Simply put, he is a professional developer on campus and a resource for faculty, staff, students and outside collaborators looking for software development expertise, especially in the realm of Web Applications.  In recent years, he has accrued specialized skills with geospatial data on the web and is a member of the Open Geospatial Consortium as well as a IIIF Maps TSG co-chair as part of his commitment to open source technologies.  
+Bryan Haberberger is the Full Stack Developer for RCG at SLU. He works in the technology stacks behind various projects, and his focus shifts sprint by sprint. Simply put, he is a professional developer on campus and a resource for faculty, staff, students, and outside collaborators looking for software development expertise, especially in the realm of Web Applications. In recent years, he has accrued specialized skills with geospatial data on the web and is a member of the Open Geospatial Consortium, as well as an IIIF Maps TSG co-chair, as part of his commitment to open-source technologies.

--- a/docs/about/community.md
+++ b/docs/about/community.md
@@ -3,20 +3,26 @@ id: community
 title: Community Engagement
 custom_edit_url: null
 ---
+
 # Community Partners
 
 ## About
+
 We welcome the participation of anyone interested in contributing to the projects in our portfolio. You can work on open issues on projects in our portfolio, create a new issue, or e-mail us if you want to be more involved.
 
 ## Git
-All our projects are stored in public GitHub repositories. To make code contributions to our repositories, you will need to know the basics about Git and GitHub. We recommend this <a href="https://youtu.be/RGOj5yH7evk">video tutorial</a>, if you are not familiar with these tools.
+
+All of our projects are stored in public GitHub repositories. To make code contributions to our repositories, you will need to know the basics about Git and GitHub. We recommend this <a href="https://youtu.be/RGOj5yH7evk">video tutorial</a>, if you are not familiar with these tools.
+
 ## Guidance
+
 When you are ready to contribute code to one of our open-source project, here is the process you should follow:
+
 1. Identify the issue you want to work on and post a comment in this issue, asking the repo maintainer to assign the issue to you.
-2. Crate a fork of our repository. Here is GitHub documentation for how to <a href="https://docs.github.com/en/enterprise-cloud@latest/get-started/quickstart/fork-a-repo">create a fork</a>
+2. Create a fork of our repository. Here is GitHub documentation for how to <a href="https://docs.github.com/en/enterprise-cloud@latest/get-started/quickstart/fork-a-repo">create a fork</a>
 3. Clone your fork of the repository. Here is GitHub documentation for how to <a href="https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository">clone a repository</a>.
 4. Follow the developer guide to install project dependencies and run the code.
 5. Make the necessary code changes to resolve the issue. Commit and push your changes frequently. Use meaningful commit messages when committing your code.
 6. Test your changes, verifying that the issue is resolved.
 7. Create a pull request - a request to merge changes from your fork of the repository to the original repository. Here is GitHub documentation for how to <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork">create a pull request</a>. Make sure to note the issue number that your pull request resolves, and include details of your solution.
-8. One of our repository maintaners will review your pull request and will either merge it with the original repo, or request some changes. If changes are requested, go back to step 5 and proceed from there.
+8. One of our repository maintainers will review your pull request and will either merge it with the original repo, or request some changes. If changes are requested, go back to step 5 and proceed from there.

--- a/docs/about/partners.md
+++ b/docs/about/partners.md
@@ -10,37 +10,33 @@ Open Source with SLU welcomes opportunities to partner with community outreach p
 
 ## Capabilities
 
-+ Developing a new generation of workforce: hands-on experiences in software engineering and open source software ecosystems 
-+ Software development & maintenance
-    + AI and ML tools
-    + Web, mobile, and desktop apps
-    + IoT and cyber-physical systems
-+	Research support. 
-    + Idea generation through short-term events.
-    + Innovations by sustained development efforts.
-    + Maintenance of existing software repositories.
-    + Open Scholarship and Open Work strategies.
-+ Open source community and ecosystem building
-+ Research software translation for community and industry impact
+- Developing a new generation of workforce: hands-on experiences in software engineering and open-source software ecosystems
+- Software development & maintenance
+  - AI and ML tools
+  - Web, mobile, and desktop apps
+  - IoT and cyber-physical systems
+- Research support
+  - Idea generation through short-term events
+  - Innovations by sustained development efforts
+  - Maintenance of existing software repositories
+  - Open Scholarship and Open Work strategies
+- Open-source community and ecosystem building
+- Research software translation for community and industry impact
 
 ## Opportunities
 
-+ Exploratory development
-+ Proof of concept
-+ Feasibility studies
-+ Skilled talent
+- Exploratory development
+- Proof of concept
+- Feasibility studies
+- Skilled talent
 
 ## Get Involved
 
-+ Internships
-+ Mentorships
-+ Sponsored events
-+ Partners on projects 
-+ Sponsor student teams
-+ FLOSS thought leadership
-+ Community advisory board 
-+ Industry consortium membership
- 
-
-
-
+- Internships
+- Mentorships
+- Sponsored events
+- Partners on projects
+- Sponsor student teams
+- FLOSS thought leadership
+- Community advisory board
+- Industry consortium membership

--- a/docs/about/students.md
+++ b/docs/about/students.md
@@ -8,8 +8,8 @@ custom_edit_url: null
 
 ## About
 
-Teams of students form the core of our efforts developing open source software. Our initial program is structured around teams of 2-4 undergraduate Computer Science students enrolled in the capstone course. Each team of undergraduate students has an assigned Tech Lead, usually a Graduate Student and sometimes a faculty or staff member. Regular project deliverables are expected from each team. Many teams work on sustainment of existing software codebases, and sometimes teams work on new projects.
+Teams of students form the core of our efforts developing open-source software. Our initial program is structured around teams of 2-4 undergraduate Computer Science students enrolled in the capstone course. Each team of undergraduate students has an assigned Tech Lead, usually a Graduate Student and sometimes a faculty or staff member. Regular project deliverables are expected from each team. Many teams work on sustainment of existing software codebases, and sometimes teams work on new projects.
 
 ## Guidance
 
-Specific guidance for students working on Open Source with SLU projects goes here... 
+Specific guidance for students working on Open Source with SLU projects is forthcoming...


### PR DESCRIPTION
When looking at the "About Us" section of the website, I had noticed a few minor problems in the text. This includes spelling mistakes, grammatical errors, and a missing name in the list of tech leads. This branch fixes the issues that I spotted when skimming through the text. To fix these issues, I mostly just modified the markdown files associated with this section in the website.