### PR TITLE
Fixes #127 : updating developers section of TPEN interfaces 

### DIFF
--- a/docs/project_tpeninterfaces/about.md
+++ b/docs/project_tpeninterfaces/about.md
@@ -20,6 +20,9 @@ These vanilla default and internally useful interfaces for the TPEN ecosystem th
   - Patrick Cuba (SLU Research Computing Group) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/cubap) 
   - Bryan Haberberger (SLU Research Computing Group) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/thehabes) 
   - Victor Onoja (Web Developer) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/jsvoo) 
+  - Camille Daugherty [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/camilledaugherty)
+  - Matthew Clendenning [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/Matthew-Clendenning)
+  - Sarah Fida Hussain [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/sarah-fidahussain-SLU)
 - **Start Date:** Jan, 2023 
 - **Adoption Date:** Aug, 2024
 - **Technologies Used:** 


### PR DESCRIPTION
What was changed?
I have updated current developers under the portfolio of TPEN interfaces.

Why was it changed?
It was changed to update new developers that will contribute to the project.

How was it changed?
added current developers names and their GitHub accounts to about.md .