### PR TITLE
ESP Project - Updated new team details

### DIFF
--- a/docs/project_esp/about.md
+++ b/docs/project_esp/about.md
@@ -17,9 +17,12 @@ The SLU computational chemistry researchers, working on understanding various pr
 - **Client** Dr. Ryan McCulla
 - **Current Tech Lead:** Siri Chandana Garimella [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/SiriChandanaGarimella) [<img src="/img/linkedin.svg" alt="linkedin" width="25" height="25" />](https://www.linkedin.com/in/sirichandana-garimella/)
 - **Developers:**
-  - Hayden Karl [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/haydenkarl22)
-  - Medhani Kalal [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/mkalal6)
-  - Raju Karmuri(alumni, prior tech lead) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/rkarmuri) [<img src="/img/linkedin.svg" alt="linkedin" width="25" height="25" />](https://www.linkedin.com/in/rajukarmuri731/)
+  - Eric Bruns (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/Ebruns4)
+  - Medhani Kalal (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/mkalal6)
+  - Sam Lyskawa (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/Lyskawa-Aonyx)
+  - Raju Karmuri (alumni, prior tech lead) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/rkarmuri) [<img src="/img/linkedin.svg" alt="linkedin" width="25" height="25" />](https://www.linkedin.com/in/rajukarmuri731/)  
+  - Hayden Karl (alumni) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/haydenkarl22)
+ 
 - **Start Date:** Jan, 2024
 - **Adoption Date:** Aug, 2022
 - **Technologies Used:**


### PR DESCRIPTION
Fixes #119 

ESP project: Updated the developers section in the ESP project with the new team details.

With the new team change, updating the developer's section in the ESP project with the latest team details is needed. So, updated the developers section with the new team member details and tagged the former team members as alumni.

Updated the following file:
project_esp/about.md file: Updated the developers section

<img width="415" alt="image" src="https://github.com/user-attachments/assets/5110af0a-be6e-4e18-9b1b-c54950e7fdfc">
