### PR TITLE
update developers list with details of new developers

### DIFF
--- a/docs/project_step_time_biofeedback/about.md
+++ b/docs/project_step_time_biofeedback/about.md
@@ -19,6 +19,8 @@ The StepTB is a project focused on developing a tool that leverages force signal
 
   - Collin Seper (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/colinseper)
   - Jack McPhillips (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/JackMcPhillips1543)
+  - Jacob Winter (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/jaywin2099)
+  - Mark Mehta (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/mmehta2669)
   - Noor Issa (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/Nissa9902)
 
 


### PR DESCRIPTION
Updated the **Developers** section of `project_step_time_biofeedback/about` to include details of new members of the development team

![image](https://github.com/user-attachments/assets/264eeb4c-c1da-43f9-8361-b6d59d2345c6)
