### PR TITLE
fix: update broken links from kebab-case to match snake_case filenames

### DIFF
--- a/docs/programs/oss/how_it_works.md
+++ b/docs/programs/oss/how_it_works.md
@@ -114,6 +114,6 @@ We measure success through multiple lenses:
 
 ---
 
-**Next:** Learn about our [Team Structure →](team-structure.md) and how different roles work together to ensure project success.
+**Next:** Learn about our [Team Structure →](team_structure.md) and how different roles work together to ensure project success.
 
-**Related:** Explore the [Student Experience →](student-experience.md) to understand how developers grow through this process.
+**Related:** Explore the [Student Experience →](student_experience.md) to understand how developers grow through this process.

--- a/docs/programs/oss/team_structure.md
+++ b/docs/programs/oss/team_structure.md
@@ -90,6 +90,6 @@ Faculty oversight and near-peer mentorship provide safety nets that allow studen
 
 ---
 
-**Next:** Discover the [Student Experience →](student-experience.md) and how developers grow through this comprehensive program.
+**Next:** Discover the [Student Experience →](student_experience.md) and how developers grow through this comprehensive program.
 
-**Related:** Learn about [How It Works →](how-it-works.md) to understand our development process.
+**Related:** Learn about [How It Works →](how_it_works.md) to understand our development process.


### PR DESCRIPTION
Update markdown links from kebab-case (ex: student-experience.md) to snake_case (ex: student_experience.md) to match filenames and prevent broken links. It looks like these are the only ones with this casing mismatch.