### PR TITLE
Fixing typos in tech lead github links

### DIFF
--- a/src/data/people/currentDevelopers.json
+++ b/src/data/people/currentDevelopers.json
@@ -42,7 +42,7 @@
   {
     "name": "Payton Guffey",
     "image": "",
-    "profileLink": "https://github.com/Payton Guffey"
+    "profileLink": "https://github.com/PGuffey"
   },
   {
     "name": "Nyla Hughes",
@@ -287,6 +287,6 @@
   {
     "name": "Atiqullah Asghari",
     "image": "",
-    "profileLink": "https://github.com/aasghari"
+    "profileLink": "https://github.com/aasghari01"
   }
 ]

--- a/src/data/people/currentTechLeads.json
+++ b/src/data/people/currentTechLeads.json
@@ -22,7 +22,7 @@
     {
         "name": "Vamsi Brahmadevi",
         "image": "",
-        "profileLink": "https://github.com/vbrahmadevi"
+        "profileLink": "https://github.com/vbramhadevi"
     },
     {
         "name": "Obsa Sendaba",
@@ -47,12 +47,12 @@
     {
         "name": "Varma Penmetsa",
         "image": "",
-        "profileLink": "https://github.com/SrinivasVarmaP"
+        "profileLink": "https://github.com/SrinivasaVarmaP"
     },
     {
         "name": "Samuel Kann",
         "image": "",
-        "profileLink": "https://github.com/drakpac"
+        "profileLink": "https://github.com/dracpak"
     },
     {
         "name": "Leandru Martin",


### PR DESCRIPTION
There were issues related to certain github profiles not showing up when clicked. After looking, some of the github usernames were mistyped. This PR addresses those typos and fixes the tech lead pages so there's no more errors.