### PR TITLE
slack-visibility

### DIFF
--- a/docs/connect_with/training.md
+++ b/docs/connect_with/training.md
@@ -68,6 +68,6 @@ Gain foundational skills in research computing while working alongside graduate 
 
 ## Registration and Schedule
 
-Workshops are offered throughout the academic year with both daytime and evening sessions to accommodate different schedules. Registration is free for SLU community members. Check our [news pages](/news) or [Join our Slack workspace](https://oss-slu.slack.com) for upcoming sessions.
+Workshops are offered throughout the academic year with both daytime and evening sessions to accommodate different schedules. Registration is free for SLU community members. Check our [news pages](/news) or [Join our Slack workspace](https://join.slack.com/t/oswslu/shared_invite/zt-24f0qhjbo-NkSfQ4LOg5wXxBdxP4vzfA) for upcoming sessions.
 
 Contact [oss@slu.edu](mailto:oss@slu.edu) to request specific topics, suggest new workshop ideas, or arrange lab-specific training sessions.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,16 +186,9 @@ const config = {
           },
           {to: '/news', label: 'News', position: 'left'},
           {
-            type: 'doc',
-            docId: 'connect_with/community',
-            label: 'Contribute',
+            type: 'custom-SlackButton',
             position: 'right',
-            className: 'button button--secondary button--lg',
-          },
-          {
-            type: 'custom-myAwesomeNavbarItem',
-            position: 'right',
-            className: 'button button--secondary button--lg',
+            className: 'navbar__item navbar__link button button--secondary button--lg',
           },
           {
             type: 'doc',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,6 +187,18 @@ const config = {
           {to: '/news', label: 'News', position: 'left'},
           {
             type: 'doc',
+            docId: 'connect_with/community',
+            label: 'Contribute',
+            position: 'right',
+            className: 'button button--secondary button--lg',
+          },
+          {
+            type: 'custom-myAwesomeNavbarItem',
+            position: 'right',
+            className: 'button button--secondary button--lg',
+          },
+          {
+            type: 'doc',
             docId: 'connect_with/donate',
             label: 'Donate',
             position: 'right',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,7 +188,7 @@ const config = {
           {
             type: 'custom-SlackButton',
             position: 'right',
-            className: 'navbar__item navbar__link button button--secondary button--lg',
+            className: 'navbar__item navbar__link',
           },
           {
             type: 'doc',

--- a/sidebars.js
+++ b/sidebars.js
@@ -90,7 +90,7 @@ const sidebars = {
       items: [
         {
           type: 'category',
-          label: 'Get involved as an individual',
+          label: 'Participate as an individual',
           link: {type: 'doc', id: 'connect_with/participants'},
           items: [
             {

--- a/sidebars.js
+++ b/sidebars.js
@@ -93,30 +93,32 @@ const sidebars = {
           label: 'Get involved as an individual',
           items: [
             {
+              type: 'category',
               label: 'Participate',
-              type: 'doc',
-              id: 'connect_with/participants',
-            },
-            {
-              label: 'Contribute',
-              type: 'doc',
-              id: 'connect_with/community'
-            },
-            {
-              label: 'Experience',
-              type: 'doc',
-              id: 'connect_with/experience'
-            },
-            {
-              label: 'Lead',
-              type: 'doc',
-              id: 'connect_with/leadership'
-            },
-            {
-              label: 'Mentor',
-              type: 'doc',
-              id: 'connect_with/mentor'
-            },
+              link: {type: 'doc', id: 'connect_with/participants'},
+              items: [
+                {
+                  label: 'Contribute',
+                  type: 'doc',
+                  id: 'connect_with/community'
+                },
+                {
+                  label: 'Experience',
+                  type: 'doc',
+                  id: 'connect_with/experience'
+                },
+                {
+                  label: 'Lead',
+                  type: 'doc',
+                  id: 'connect_with/leadership'
+                },
+                {
+                  label: 'Mentor',
+                  type: 'doc',
+                  id: 'connect_with/mentor'
+                },
+              ]
+            }
           ]
         },
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -91,34 +91,28 @@ const sidebars = {
         {
           type: 'category',
           label: 'Get involved as an individual',
+          link: {type: 'doc', id: 'connect_with/participants'},
           items: [
             {
-              type: 'category',
-              label: 'Participate',
-              link: {type: 'doc', id: 'connect_with/participants'},
-              items: [
-                {
-                  label: 'Contribute',
-                  type: 'doc',
-                  id: 'connect_with/community'
-                },
-                {
-                  label: 'Experience',
-                  type: 'doc',
-                  id: 'connect_with/experience'
-                },
-                {
-                  label: 'Lead',
-                  type: 'doc',
-                  id: 'connect_with/leadership'
-                },
-                {
-                  label: 'Mentor',
-                  type: 'doc',
-                  id: 'connect_with/mentor'
-                },
-              ]
-            }
+              label: 'Contribute',
+              type: 'doc',
+              id: 'connect_with/community'
+            },
+            {
+              label: 'Experience',
+              type: 'doc',
+              id: 'connect_with/experience'
+            },
+            {
+              label: 'Lead',
+              type: 'doc',
+              id: 'connect_with/leadership'
+            },
+            {
+              label: 'Mentor',
+              type: 'doc',
+              id: 'connect_with/mentor'
+            },
           ]
         },
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -118,12 +118,8 @@ const sidebars = {
         {
           type: 'category',
           label: 'Partner as an organization',
+          link: {type: 'doc', id: 'connect_with/partners'},
           items: [
-            {
-              label: 'Partner',
-              type: 'doc',
-              id: 'connect_with/partners',
-            },
             {
               label: 'Engage Programs',
               type: 'doc',
@@ -149,11 +145,8 @@ const sidebars = {
         {
           type: 'category',
           label: 'Consult with an expert',
+          link: {type: 'doc', id: 'connect_with/consult'},
           items: [
-          { 
-            type: 'doc',
-            id: 'connect_with/consult',
-          },
           {
             label: 'Research Software Consults',
             type: 'doc',

--- a/src/components/SlackButton.js
+++ b/src/components/SlackButton.js
@@ -1,10 +1,15 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 function SlackButton({ className }) {
   return (
-    <a className={className} title={"Open link to Slack channel in a new tab"} onClick={() => {
-      window.open('https://join.slack.com/t/oswslu/shared_invite/zt-24f0qhjbo-NkSfQ4LOg5wXxBdxP4vzfA', '_blank').focus()
-    }}>Contribute</a>
+    <Link
+      className={className + ' button button--secondary button--lg'}
+      title={"Open link to Slack channel in a new tab"}
+      to='/connect_with/community'
+    >
+      Contribute
+    </Link>
   )
 }
 

--- a/src/components/SlackButton.js
+++ b/src/components/SlackButton.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from '../pages/index.module.css';
+
+function SlackButton() {
+  return (
+    <button className='button button--secondary button--lg' title={"Open link to Slack channel in a new tab"} onClick={() => {
+      window.open('https://join.slack.com/t/oswslu/shared_invite/zt-24f0qhjbo-NkSfQ4LOg5wXxBdxP4vzfA', '_blank').focus()
+    }}>Contribute</button>
+  )
+}
+
+export default SlackButton;

--- a/src/components/SlackButton.js
+++ b/src/components/SlackButton.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import styles from '../pages/index.module.css';
 
-function SlackButton() {
+function SlackButton({ className }) {
   return (
-    <button className='button button--secondary button--lg' title={"Open link to Slack channel in a new tab"} onClick={() => {
+    <a className={className} title={"Open link to Slack channel in a new tab"} onClick={() => {
       window.open('https://join.slack.com/t/oswslu/shared_invite/zt-24f0qhjbo-NkSfQ4LOg5wXxBdxP4vzfA', '_blank').focus()
-    }}>Contribute</button>
+    }}>Contribute</a>
   )
 }
 

--- a/src/theme/NavbarItem/ComponentTypes.js
+++ b/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import SlackButton from '@site/src/components/SlackButton';
+
+export default {
+  ...ComponentTypes,
+  'custom-myAwesomeNavbarItem': SlackButton,
+};

--- a/src/theme/NavbarItem/ComponentTypes.js
+++ b/src/theme/NavbarItem/ComponentTypes.js
@@ -3,5 +3,5 @@ import SlackButton from '@site/src/components/SlackButton';
 
 export default {
   ...ComponentTypes,
-  'custom-myAwesomeNavbarItem': SlackButton,
+  'custom-SlackButton': SlackButton,
 };


### PR DESCRIPTION
I felt there was some difficulty in locating the link to the Slack workspace. This PR attempts to improve the visibility of the link, in part by adjusting some navigational elements to make it clearer which pages are intended to provide resources for incoming contributors and which are for other purposes.

When I initially was looking for the link, I saw the sidebar had a link under "Connect with OSS > Get involved as an individual" labeled "Participate," and another labeled "Contribute." I got confused when "Participate" did not have a link listed there and was instead a directory to other pages, as the name and placement within the sidebar made it seem like it would have the same function as the "Contribute" link. So, in this PR I have moved it in the sidebar view to make its purpose as a directory to other subpages clearer. Other links in the sidebar are structured the same (as directories to other pages), so to keep the structure consistent I rearranged those in the sidebar as well.

With this I think I have addressed most of what caused my confusion in finding the link--I also acknowledge that I was navigating the interface with a different purpose from what a contributor would usually have, in that I was looking for a very specific link and not trying to find general information on how to participate. So I wasn't reading the paragraphs very thoroughly; I think the text on the pages makes the navigation make more sense when I read them from that angle.

However, should there also be added buttons or links elsewhere in the interface? I'm not sure it's fully necessary, but I can add something in if need be.