### PR TITLE
Add dependabot.yml to exclude webpack from grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "webpack"


### PR DESCRIPTION
## Summary

- Adds a `dependabot.yml` configuration file to give explicit control over how Dependabot groups dependency updates
- Excludes `webpack` from the grouped npm update PR, since webpack 5.106.x is incompatible with Docusaurus 3.10.0 (ProgressPlugin schema mismatch causes build failure)
- Webpack will still receive its own separate Dependabot PR when a compatible version is available

## Context

PR #266 bundles 9 dependency updates including several security fixes (lodash, ajv, path-to-regexp, picomatch, brace-expansion, qs). The webpack bump breaks the build, blocking all the security fixes from landing. Comment-based `@dependabot ignore` commands did not reliably exclude webpack from the group, so this config-level fix is more durable.

## Test plan

- [ ] Dependabot picks up the new config and regenerates grouped PRs without webpack
- [ ] Grouped security updates build successfully without webpack included
- [ ] Webpack gets its own separate PR (can be deferred until Docusaurus compatibility is resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)