### PR TITLE
Add stats headers and project metadata to website

### DIFF
--- a/docs/people/contributors.mdx
+++ b/docs/people/contributors.mdx
@@ -1,14 +1,17 @@
 ---
 id: contributors
-title: Contributors
+title: Alumni Contributors
 custom_edit_url: null
 ---
 
+import ContributorsHeader from '../../src/components/people/ContributorsHeader';
 import PrevTechLeads from '../../src/components/people/PrevTechLeads';
 import PrevDevelopers from '../../src/components/people/PrevDevelopers';
 import PrevStaff from '../../src/components/people/PrevStaff';
 
-These talented developers contributed to Open Source with SLU software.
+<ContributorsHeader />
+
+These talented developers built real software for real clients during their time with Open Source with SLU. They shipped research tools, web applications, mobile apps, APIs, and more. Many have gone on to exciting roles in industry at companies across the technology landscape, bringing the skills they developed here to teams around the world. We are proud of every one of them.
 
 ## Previous Staff
 

--- a/docs/people/staff.mdx
+++ b/docs/people/staff.mdx
@@ -5,9 +5,12 @@ custom_edit_url: null
 hide_title: true
 ---
 
+import CurrentTeamHeader from '../../src/components/people/CurrentTeamHeader';
 import CurrentDevelopers from '../../src/components/people/CurrentDevelopers';
 import CurrentTechLeads from '../../src/components/people/CurrentTechLeads';
 import CurrentStaff from '../../src/components/people/CurrentStaff';
+
+<CurrentTeamHeader />
 
 ## Staff Developers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@docusaurus/types": "3.10.0"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/src/components/HomepageStats/index.js
+++ b/src/components/HomepageStats/index.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import projects from '../../data/projects/Projects.json';
+import currentDevelopers from '../../data/people/currentDevelopers.json';
+import currentTechLeads from '../../data/people/currentTechLeads.json';
+import currentStaff from '../../data/people/currentStaff.json';
+import prevDevelopers from '../../data/people/prevDevelopers.json';
+import prevTechLeads from '../../data/people/prevTechLeads.json';
+import prevStaff from '../../data/people/prevStaff.json';
+import styles from './styles.module.css';
+
+export default function HomepageStats() {
+  const current = currentDevelopers.length + currentTechLeads.length + currentStaff.length;
+  const alumni = prevDevelopers.length + prevTechLeads.length + prevStaff.length;
+  const totalPeople = current + alumni;
+
+  const totalProjects = projects.length;
+  const researchCount = projects.filter(p => p.research).length;
+  const projectCounts = {};
+  for (const p of projects) {
+    projectCounts[p.status] = (projectCounts[p.status] || 0) + 1;
+  }
+
+  const domainCount = new Set(projects.flatMap(p => p.domain || [])).size;
+
+  return (
+    <section className={styles.statsSection}>
+      <div className={styles.statsRow}>
+        {/* Portfolio stats: wider, left — mirrors the text column above */}
+        <div className={`stats-header ${styles.portfolioCard}`}>
+          <h3 className={styles.cardTitle}>Projects</h3>
+          <div className="stats-row">
+            <div className="stat-item stat-item--total">
+              <span className="stat-number">{totalProjects}</span>
+              <span className="stat-label">Total</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-number">{projectCounts.current || 0}</span>
+              <span className="stat-label">Active</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-number">{projectCounts.stable || 0}</span>
+              <span className="stat-label">Stable</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-number">{projectCounts.completed || 0}</span>
+              <span className="stat-label">Completed</span>
+            </div>
+            <div className="stat-item stat-item--divider">
+              <span className="stat-number">{researchCount}</span>
+              <span className="stat-label">Research</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-number">{domainCount}</span>
+              <span className="stat-label">Domains</span>
+            </div>
+          </div>
+          <Link className={styles.cardLink} to="/projects/portfolio">
+            View portfolio &rarr;
+          </Link>
+        </div>
+
+        {/* Contributors stats: narrower, right — mirrors the carousel column above */}
+        <div className={`stats-header ${styles.contributorsCard}`}>
+          <h3 className={styles.cardTitle}>Contributors</h3>
+          <div className="stats-row">
+            <div className="stat-item stat-item--total">
+              <span className="stat-number">{totalPeople}</span>
+              <span className="stat-label">Total</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-number">{currentStaff.length + prevStaff.length}</span>
+              <span className="stat-label">Staff</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-number">{currentTechLeads.length + prevTechLeads.length}</span>
+              <span className="stat-label">Tech Leads</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-number">{currentDevelopers.length + prevDevelopers.length}</span>
+              <span className="stat-label">Developers</span>
+            </div>
+          </div>
+          <Link className={styles.cardLink} to="/people/staff">
+            Meet the current team &rarr;
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/HomepageStats/styles.module.css
+++ b/src/components/HomepageStats/styles.module.css
@@ -28,10 +28,11 @@
   min-width: 260px;
 }
 
-/* Narrower: matches the text column width above */
+/* Narrower: matches the text column width above; offset down for staggered effect */
 .contributorsCard {
   flex: 1 1 300px;
   min-width: 260px;
+  margin-top: 1.5rem;
 }
 
 .cardTitle {

--- a/src/components/HomepageStats/styles.module.css
+++ b/src/components/HomepageStats/styles.module.css
@@ -1,0 +1,66 @@
+/*
+ * Staggered two-column layout that mirrors the intro section above:
+ *   Left (portfolio):    wider  — aligns under the "What is OSS?" text
+ *   Right (contributors): narrower — aligns under the carousel image
+ *
+ * The intro section uses flex: 1 1 300px (text) / flex: 1 1 400px (carousel).
+ * We flip the proportions so the wider card sits under the text column
+ * and the narrower card sits under the image column.
+ */
+
+.statsSection {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem 2rem;
+}
+
+.statsRow {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+/* Wider: matches the carousel column width above */
+.portfolioCard {
+  flex: 1 1 400px;
+  min-width: 260px;
+}
+
+/* Narrower: matches the text column width above */
+.contributorsCard {
+  flex: 1 1 300px;
+  min-width: 260px;
+}
+
+.cardTitle {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cardLink {
+  display: block;
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .statsSection {
+    padding: 0 2rem 2rem;
+  }
+
+  .statsRow {
+    flex-direction: column;
+  }
+
+  .portfolioCard,
+  .contributorsCard {
+    flex: unset;
+    width: 100%;
+  }
+}

--- a/src/components/people/ContributorsHeader/index.js
+++ b/src/components/people/ContributorsHeader/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import prevDevelopers from '../../../data/people/prevDevelopers.json';
+import prevTechLeads from '../../../data/people/prevTechLeads.json';
+import prevStaff from '../../../data/people/prevStaff.json';
+import currentDevelopers from '../../../data/people/currentDevelopers.json';
+import currentTechLeads from '../../../data/people/currentTechLeads.json';
+import currentStaff from '../../../data/people/currentStaff.json';
+
+export default function ContributorsHeader() {
+  const alumni = prevDevelopers.length + prevTechLeads.length + prevStaff.length;
+  const current = currentDevelopers.length + currentTechLeads.length + currentStaff.length;
+  const total = alumni + current;
+
+  return (
+    <div className="stats-header">
+      <div className="stats-row">
+        <div className="stat-item stat-item--total">
+          <span className="stat-number">{total}</span>
+          <span className="stat-label">Total</span>
+        </div>
+        <div className="stat-item">
+          <span className="stat-number">{prevStaff.length}</span>
+          <span className="stat-label">Staff</span>
+        </div>
+        <div className="stat-item">
+          <span className="stat-number">{prevTechLeads.length}</span>
+          <span className="stat-label">Tech Leads</span>
+        </div>
+        <div className="stat-item">
+          <span className="stat-number">{prevDevelopers.length}</span>
+          <span className="stat-label">Developers</span>
+        </div>
+        <Link className="stat-item stat-item--divider" to="/people/staff">
+          <span className="stat-number">{current}</span>
+          <span className="stat-label">Active Now</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/people/CurrentTeamHeader/index.js
+++ b/src/components/people/CurrentTeamHeader/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import currentDevelopers from '../../../data/people/currentDevelopers.json';
+import currentTechLeads from '../../../data/people/currentTechLeads.json';
+import currentStaff from '../../../data/people/currentStaff.json';
+import prevDevelopers from '../../../data/people/prevDevelopers.json';
+import prevTechLeads from '../../../data/people/prevTechLeads.json';
+import prevStaff from '../../../data/people/prevStaff.json';
+
+export default function CurrentTeamHeader() {
+  const total = currentDevelopers.length + currentTechLeads.length + currentStaff.length;
+  const alumni = prevDevelopers.length + prevTechLeads.length + prevStaff.length;
+
+  return (
+    <div className="stats-header">
+      <div className="stats-row">
+        <div className="stat-item stat-item--total">
+          <span className="stat-number">{total}</span>
+          <span className="stat-label">Current Team</span>
+        </div>
+        <div className="stat-item">
+          <span className="stat-number">{currentStaff.length}</span>
+          <span className="stat-label">Staff</span>
+        </div>
+        <div className="stat-item">
+          <span className="stat-number">{currentTechLeads.length}</span>
+          <span className="stat-label">Tech Leads</span>
+        </div>
+        <div className="stat-item">
+          <span className="stat-number">{currentDevelopers.length}</span>
+          <span className="stat-label">Developers</span>
+        </div>
+        <Link className="stat-item stat-item--divider" to="/people/contributors">
+          <span className="stat-number">{alumni}</span>
+          <span className="stat-label">Alumni</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/projects/ProjectsPage.js
+++ b/src/components/projects/ProjectsPage.js
@@ -1,64 +1,82 @@
 import React from 'react';
 import projects from '../../data/projects/Projects.json';
+import { kindLabels, domainLabels } from '../../data/projects/productTypes';
 import ProjectCard from './ProjectCard';
 import '../../css/ProjectsPage.css';
 
-const highlights = [
-    {
-      title: "Technologies We Use",
-      items: [
-        { icon: "🧠", text: "AI/ML" },
-        { icon: "⚙️", text: "IoT" },
-        { icon: "🌐", text: "Web Development" },
-        { icon: "📊", text: "Data Visualization" },
-        { icon: "🎤", text: "Speech Processing" },
-        { icon: "📈", text: "ETL Pipelines" },
-      ],
-    },
-    {
-      title: "Industries Served",
-      items: [
-        { icon: "🏥", text: "Healthcare" },
-        { icon: "🧪", text: "Research" },
-        { icon: "🎓", text: "Education" },
-        { icon: "✈️", text: "Aerospace" },
-        { icon: "🧬", text: "Bioinformatics" },
-        { icon: "📚", text: "Digital Humanities" },
-      ],
-    },
-    {
-      title: "Core Capabilities",
-      items: [
-        { icon: "🔎", text: "Data Processing" },
-        { icon: "🖼️", text: "Image Recognition" },
-        { icon: "🗣️", text: "Speech Evaluation" },
-        { icon: "📱", text: "Mobile Apps" },
-        { icon: "🔬", text: "Scientific Visualization" },
-      ],
-    },
-  ];
-  
-  const Highlights = () => {
-    return (
-      <div className="highlights-container">
-        <div className="highlights-grid">
-          {highlights.map((section, idx) => (
-            <div key={idx} className="highlights-card">
-              <h3 className="highlights-title">{section.title}</h3>
-              <ul className="highlights-list">
-                {section.items.map((item, itemIdx) => (
-                  <li key={itemIdx} className="highlights-item">
-                    <span className="highlights-icon">{item.icon}</span>
-                    <span>{item.text}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+// Future use: richer highlight cards for technologies, industries, and capabilities.
+// const highlights = [
+//   {
+//     title: "Technologies We Use",
+//     items: ["AI/ML", "IoT", "Web Development", "Data Visualization",
+//             "Speech Processing", "ETL Pipelines"],
+//   },
+//   {
+//     title: "Industries Served",
+//     items: ["Healthcare", "Research", "Education", "Aerospace",
+//             "Bioinformatics", "Digital Humanities"],
+//   },
+//   {
+//     title: "Core Capabilities",
+//     items: ["Data Processing", "Image Recognition", "Speech Evaluation",
+//             "Mobile Apps", "Scientific Visualization"],
+//   },
+// ];
+
+const statusLabels = {
+  current: 'Active',
+  stable: 'Stable & Supported',
+  completed: 'Completed',
+};
+
+function PortfolioHeader() {
+  const total = projects.length;
+  const researchCount = projects.filter(p => p.research).length;
+  const counts = {};
+  for (const p of projects) {
+    counts[p.status] = (counts[p.status] || 0) + 1;
+  }
+
+  // Derive the sets of kinds and domains actually present in the data.
+  const kinds = [...new Set(projects.map(p => p.kind))];
+  const kindList = kinds
+    .map(k => kindLabels[k] || k)
+    .sort()
+    .join(' \u00b7 ');
+
+  const domains = [...new Set(projects.flatMap(p => p.domain || []))];
+  const domainList = domains
+    .map(d => domainLabels[d] || d)
+    .sort()
+    .join(' \u00b7 ');
+
+  return (
+    <div className="stats-header">
+      <div className="stats-row">
+        <div className="stat-item stat-item--total">
+          <span className="stat-number">{total}</span>
+          <span className="stat-label">Total</span>
+        </div>
+        {Object.entries(statusLabels).map(([key, label]) => (
+          <div key={key} className="stat-item">
+            <span className="stat-number">{counts[key] || 0}</span>
+            <span className="stat-label">{label}</span>
+          </div>
+        ))}
+        <div className="stat-item stat-item--divider">
+          <span className="stat-number">{researchCount}</span>
+          <span className="stat-label">Research</span>
         </div>
       </div>
-    );
-  };
+      <p className="stats-subtitle">
+        <strong>Product types:</strong> {kindList}
+      </p>
+      <p className="stats-subtitle">
+        <strong>Domains:</strong> {domainList}
+      </p>
+    </div>
+  );
+}
 
 export default function ProjectsPage() {
   const sections = [
@@ -69,7 +87,7 @@ export default function ProjectsPage() {
 
   return (
     <>
-      {/* <Highlights /> */}
+      <PortfolioHeader />
       <div className="projects-page">
         {sections.map(section => (
           <div key={section.key}>
@@ -87,5 +105,4 @@ export default function ProjectsPage() {
       </div>
     </>
   );
-  
 }

--- a/src/components/projects/ProjectsPage.js
+++ b/src/components/projects/ProjectsPage.js
@@ -4,25 +4,6 @@ import { kindLabels, domainLabels } from '../../data/projects/productTypes';
 import ProjectCard from './ProjectCard';
 import '../../css/ProjectsPage.css';
 
-// Future use: richer highlight cards for technologies, industries, and capabilities.
-// const highlights = [
-//   {
-//     title: "Technologies We Use",
-//     items: ["AI/ML", "IoT", "Web Development", "Data Visualization",
-//             "Speech Processing", "ETL Pipelines"],
-//   },
-//   {
-//     title: "Industries Served",
-//     items: ["Healthcare", "Research", "Education", "Aerospace",
-//             "Bioinformatics", "Digital Humanities"],
-//   },
-//   {
-//     title: "Core Capabilities",
-//     items: ["Data Processing", "Image Recognition", "Speech Evaluation",
-//             "Mobile Apps", "Scientific Visualization"],
-//   },
-// ];
-
 const statusLabels = {
   current: 'Active',
   stable: 'Stable & Supported',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -313,7 +313,7 @@
   transform: scale(1.1);
 }
 
-/* Stats header - shared by Portfolio and Contributors pages */
+/* Stats header - shared by Homepage, Portfolio, and Contributors pages */
 .stats-header {
   margin-bottom: 2rem;
   padding: 1.5rem 2rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -312,3 +312,89 @@
 .badge img:hover {
   transform: scale(1.1);
 }
+
+/* Stats header - shared by Portfolio and Contributors pages */
+.stats-header {
+  margin-bottom: 2rem;
+  padding: 1.5rem 2rem;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 12px;
+  border-left: 4px solid var(--ifm-color-primary);
+  width: fit-content;
+}
+
+.stats-row {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.stat-item {
+  text-align: center;
+}
+
+a.stat-item {
+  text-decoration: none;
+  transition: opacity 0.2s;
+}
+
+a.stat-item:hover {
+  text-decoration: none;
+  opacity: 0.75;
+}
+
+.stat-item--total {
+  padding-right: 2rem;
+  border-right: 2px solid var(--ifm-color-emphasis-300);
+}
+
+.stat-item--divider {
+  padding-left: 2rem;
+  border-left: 2px solid var(--ifm-color-emphasis-300);
+}
+
+.stat-number {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  line-height: 1;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-top: 0.25rem;
+}
+
+.stats-subtitle {
+  margin: 1rem 0 0;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+@media (max-width: 480px) {
+  .stats-row {
+    gap: 1.25rem;
+  }
+
+  .stat-item--total {
+    width: 100%;
+    padding-right: 0;
+    border-right: none;
+    border-bottom: 2px solid var(--ifm-color-emphasis-300);
+    padding-bottom: 1rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .stat-item--divider {
+    padding-left: 0;
+    border-left: none;
+  }
+
+  .stat-number {
+    font-size: 1.5rem;
+  }
+}

--- a/src/data/projects/Projects.json
+++ b/src/data/projects/Projects.json
@@ -4,335 +4,479 @@
       "url": "/projects/baio/about",
       "description": "This project is focused on developing an AI-driven tool that supports bioinformatics research by providing intelligent API recommendations, detecting errors, and offering real-time corrections. The tool leverages large language models trained on bioinformatics codebases to ensure reliable data retrieval and analysis, ultimately improving research accuracy and efficiency.",
       "status": "current",
-      "image": "/img/projects/baio.png"
+      "image": "/img/projects/baio.png",
+      "kind": "web-app",
+      "domain": ["life-sciences", "ai-ml"],
+      "research": true
     },
     {
       "name": "Bubble Scan",
       "url": "/projects/bubblescan/about",
       "description": "The bubble scan is a web application where the user provides digital copies of standard paper scantron sheets in a PDF format and the software produces tabular results in a CSV file.",
       "status": "stable",
-      "image": "/img/projects/bubblescan.png"
+      "image": "/img/projects/bubblescan.png",
+      "kind": "web-app",
+      "domain": ["education", "work-management", "ai-ml"],
+      "research": false
     },
     {
       "name": "CivicKit",
       "url": "/projects/civickit/about",
       "description": "CivicKit is an open-source toolkit for civic engagement, providing reusable components and templates that help communities build digital tools for local governance and participation.",
       "status": "current",
-      "image": "/img/projects/default.png"
+      "image": "/img/projects/default.png",
+      "kind": "library",
+      "domain": ["civic", "entrepreneurship"],
+      "research": false
     },
     {
       "name": "Congestion Control Emulator",
       "url": "https://github.com/oss-slu/Congestion-control-emulator",
       "description": "CLI application that emulates a network and runs congestion control algorithms under various network conditions.",
       "status": "completed",
-      "image": "/img/projects/congestion_control_emulator.png"
+      "image": "/img/projects/congestion_control_emulator.png",
+      "kind": "cli",
+      "domain": ["networking"],
+      "research": true
     },
     {
       "name": "CoreDesk",
       "url": "/projects/coredesk/about",
       "description": "CoreDesk is a web-based work management tool that enables shared service providers in universities and similar contexts. It was originally built to support the SLU Center for Additive Manufacturing (SLU-CAM), and is expanding to support a variety of use cases.",
       "status": "current",
-      "image": "/img/projects/open_project.png"
+      "image": "/img/projects/open_project.png",
+      "kind": "web-app",
+      "domain": ["work-management", "manufacturing", "education"],
+      "research": false
     },
     {
       "name": "CV Zebrafish",
       "url": "/projects/cv_zebrafish/about",
       "description": "CV Zebrafish is a web application that automates the analysis of zebrafish body parts and movement from high-speed video recordings.",
       "status": "current",
-      "image": "/img/projects/cv_zebrafish.png"
+      "image": "/img/projects/cv_zebrafish.png",
+      "kind": "web-app",
+      "domain": ["life-sciences", "ai-ml", "simulation"],
+      "research": true
     },
     {
       "name": "DADS: Database of Arithmetic Dynamical Systems",
       "url": "/projects/dads/about",
       "description": "DADS is a flexible, web-based, search-driven user interface for a database of information about a class of mathematical functions known as arithmetic dynamical systems.",
       "status": "current",
-      "image": "/img/projects/dads.png"
+      "image": "/img/projects/dads.png",
+      "kind": "web-app",
+      "domain": ["mathematics"],
+      "research": true
     },
     {
       "name": "DEER: Data Entry & Exhibition for Rerum",
       "url": "/projects/deer/about",
       "description": "A designer's framework for non-destructive annotation and template rendering for distributed digital resources and collections.",
       "status": "stable",
-      "image": "/img/projects/deer.png"
+      "image": "/img/projects/deer.png",
+      "kind": "library",
+      "domain": ["digital-humanities"],
+      "research": true
     },
     {
       "name": "Digital Bone Box",
       "url": "/projects/digital_bone_box/about",
       "description": "DBB is a web application for displaying and editing sets of annotated anatomical images. The project started with an a set of annotated human bones.",
       "status": "current",
-      "image": "/img/projects/digital_bone_box.png"
+      "image": "/img/projects/digital_bone_box.png",
+      "kind": "web-app",
+      "domain": ["education", "healthcare"],
+      "research": true
     },
     {
       "name": "Drone World",
       "url": "/projects/droneworld/about",
       "description": "Drone World is a platform for testing small unmanned aerial systems (sUAS) applications by simulating realistic test scenarios based on specified requirements.",
       "status": "current",
-      "image": "/img/projects/droneworld.png"
+      "image": "/img/projects/droneworld.png",
+      "kind": "platform",
+      "domain": ["aerospace", "simulation"],
+      "research": true
     },
     {
       "name": "DroneSwarm",
       "url": "",
       "description": "Recover and update drone swarm research software.",
       "status": "completed",
-      "image": "/img/projects/droneswarm.png"
+      "image": "/img/projects/droneswarm.png",
+      "kind": "iot",
+      "domain": ["aerospace", "robotics"],
+      "research": true
     },
     {
       "name": "ESP: Electronic Structure Parser",
       "url": "/projects/esp/about",
       "description": "ESP is a web application that allows the user to upload the ORCA/Gaussian data, and quickly extract relevant tabular results in a Word document.",
       "status": "stable",
-      "image": "/img/projects/esp.png"
+      "image": "/img/projects/esp.png",
+      "kind": "web-app",
+      "domain": ["life-sciences", "chemistry"],
+      "research": true
     },
     {
       "name": "Gallery of Glosses",
       "url": "/projects/gallery_of_glosses/about",
       "description": "Interfaces to view and manage Glosses.",
       "status": "stable",
-      "image": "/img/projects/gallery_of_glosses.png"
+      "image": "/img/projects/gallery_of_glosses.png",
+      "kind": "web-app",
+      "domain": ["digital-humanities"],
+      "research": true
     },
     {
       "name": "GradEval360",
       "url": "/projects/gradeval360/about",
       "description": "GradEval360 is a comprehensive graduate program evaluation platform that streamlines the collection, analysis, and reporting of program assessment data.",
       "status": "current",
-      "image": "/img/projects/default.png"
+      "image": "/img/projects/default.png",
+      "kind": "web-app",
+      "domain": ["education", "work-management"],
+      "research": false
     },
     {
       "name": "HPC Projects",
       "url": "/projects/hpc_projects/about",
       "description": "HPC Projects encompasses work on SLU's high-performance computing resources, including the eARM molecular modeling pipeline and an AI-powered RAG chatbot for HPC documentation and system interaction.",
       "status": "stable",
-      "image": "/img/projects/hpc_rag_agent_chatbot.png"
+      "image": "/img/projects/hpc_rag_agent_chatbot.png",
+      "kind": "service",
+      "domain": ["life-sciences", "ai-ml"],
+      "research": true
     },
     {
       "name": "Inner Peace Time",
       "url": "/projects/innerpeacetime/about",
       "description": "Inner peace time is a guided meditation app developed to help children and families breathe for calm and find their safe place for LOVE and HEALING.",
       "status": "stable",
-      "image": "/img/projects/innerpeacetime.png"
+      "image": "/img/projects/innerpeacetime.png",
+      "kind": "mobile-app",
+      "domain": ["healthcare"],
+      "research": true
     },
     {
       "name": "iperf3",
       "url": "/projects/iperf/about",
       "description": "Contributing to the open-source iperf3 network performance measurement tool, focusing on testing, documentation, and feature development.",
       "status": "current",
-      "image": "/img/projects/default.png"
+      "image": "/img/projects/default.png",
+      "kind": "cli",
+      "domain": ["networking"],
+      "research": false
     },
     {
       "name": "IRIS: Image Recognition Integration System",
       "url": "/projects/iris/about",
       "description": "IRIS is a framework for creating custom mobile applications that can handle specialized image search problems. The framework was developed to create an application that uses a custom AI model to identify details about orthopedic screws from x-ray images of a patient.",
       "status": "stable",
-      "image": "/img/projects/iris.png"
+      "image": "/img/projects/iris.png",
+      "kind": "library",
+      "domain": ["healthcare", "ai-ml"],
+      "research": true
     },
     {
       "name": "iSpraak",
       "url": "/projects/ispraak/about",
       "description": "Automates speech evaluation of language learners and to provide them with instantaneous corrective feedback.",
       "status": "completed",
-      "image": "/img/projects/ispraak.png"
+      "image": "/img/projects/ispraak.png",
+      "kind": "web-app",
+      "domain": ["speech-language", "ai-ml", "education"],
+      "research": true
     },
     {
       "name": "MaterialDerailleur",
       "url": "/projects/md/about",
       "description": "MaterialDerailleur shifts donations into drive for BWorks. It streamlines the process of managing material donations, providing a transparent view into the journey of each donated item.",
       "status": "current",
-      "image": "/img/projects/md.png"
+      "image": "/img/projects/md.png",
+      "kind": "web-app",
+      "domain": ["civic", "work-management"],
+      "research": false
     },
     {
       "name": "MechatronicsVR",
       "url": "/projects/mechatronics_vr/about",
       "description": "MechatronicsVR provides an interactive VR environment for learning mechanical assembly skills.",
       "status": "current",
-      "image": "/img/projects/vr_robotics.png"
+      "image": "/img/projects/vr_robotics.png",
+      "kind": "vr",
+      "domain": ["education", "robotics", "simulation"],
+      "research": true
     },
     {
       "name": "MeltShiny",
       "url": "/projects/meltshiny/about",
       "description": "MeltShiny is a web application that automates the analysis and visualization of DNA melting curves for researchers in chemistry, biology, and genetics.",
       "status": "stable",
-      "image": "/img/projects/meltshiny.png"
+      "image": "/img/projects/meltshiny.png",
+      "kind": "web-app",
+      "domain": ["life-sciences", "chemistry"],
+      "research": true
     },
     {
       "name": "Mithridatium",
       "url": "/projects/mithridatium/about",
       "description": "Mithridatium is a set of tools that translates research on detecting and prevention of AI poisoning attacks into practical software solutions.",
       "status": "current",
-      "image": "/img/projects/mithridatium.png"
+      "image": "/img/projects/mithridatium.png",
+      "kind": "platform",
+      "domain": ["cybersecurity", "ai-ml", "dev-tools"],
+      "research": true
     },
     {
       "name": "ML Code Generator",
       "url": "https://github.com/oss-slu/ml_code_generator",
       "description": "A point and click user interface for generating python code for machine learning (ML) pipelines.",
       "status": "completed",
-      "image": "/img/projects/ml_code_generator.png"
+      "image": "/img/projects/ml_code_generator.png",
+      "kind": "web-app",
+      "domain": ["ai-ml", "education"],
+      "research": false
     },
     {
       "name": "Montis Peaks 3D",
       "url": "/projects/montis/about",
       "description": "Montis Peaks 3D is an interactive 3D mountain peak visualization and exploration tool built for outdoor enthusiasts and geographic education.",
       "status": "stable",
-      "image": "/img/projects/default.png"
+      "image": "/img/projects/default.png",
+      "kind": "web-app",
+      "domain": ["geospatial", "education", "civic", "entrepreneurship"],
+      "research": false
     },
     {
       "name": "MORPH",
       "url": "/projects/morph/about",
       "description": "MORPH (Modular Open-source Robotic Programming Hub) is a collection of educational robotics kits, software modules, lesson plans, learning materials, and a platform that makes them simple to use.",
       "status": "current",
-      "image": "/img/projects/smartrobot.png"
+      "image": "/img/projects/smartrobot.png",
+      "kind": "platform",
+      "domain": ["education", "robotics", "entrepreneurship"],
+      "research": false
     },
     {
       "name": "Mouser",
       "url": "/projects/mouser/about",
       "description": "Mouser is a desktop app for tracking the data of animal experiments.",
       "status": "current",
-      "image": "/img/projects/mouser.png"
+      "image": "/img/projects/mouser.png",
+      "kind": "desktop-app",
+      "domain": ["life-sciences", "work-management"],
+      "research": true
     },
     {
       "name": "Open Energy Dashboard",
       "url": "/projects/open_energy_dashboard/about",
       "description": "Open Energy Dashboard is a user-friendly way to display energy information from smart energy meters or uploaded via CSV files.",
       "status": "completed",
-      "image": "/img/projects/open_energy_dashboard.png"
+      "image": "/img/projects/open_energy_dashboard.png",
+      "kind": "web-app",
+      "domain": ["energy", "work-management"],
+      "research": false
     },
     {
       "name": "OSS CI/CD & Automation",
       "url": "/projects/cicd_automation/about",
       "description": "OSS CI/CD & Automation project provides continuous integration and continuous deployment (CI/CD) services to open source projects developed at SLU, including automated testing, deployment pipelines, and release management.",
       "status": "current",
-      "image": "/img/projects/cicd_automation.png"
+      "image": "/img/projects/cicd_automation.png",
+      "kind": "service",
+      "domain": ["devops"],
+      "research": false
     },
     {
       "name": "OSS Cybersecurity",
       "url": "/projects/oss_cybersecurity/about",
       "description": "The OSS Cybersecurity project provides cybersecurity services to open source projects developed at SLU, including security assessments, vulnerability scanning, and best practices guidance.",
       "status": "current",
-      "image": "/img/projects/default.png"
+      "image": "/img/projects/default.png",
+      "kind": "service",
+      "domain": ["devops", "cybersecurity"],
+      "research": false
     },
     {
       "name": "OSS Dev Analytics",
       "url": "/projects/dev_analytics/about",
       "description": "OSS Dev Analytics project provides developer analytics and general data analytics support to open source projects developed at SLU.",
       "status": "current",
-      "image": "/img/projects/dev_analytics.png"
+      "image": "/img/projects/dev_analytics.png",
+      "kind": "service",
+      "domain": ["devops", "data"],
+      "research": false
     },
     {
       "name": "OSS Infra/Ops",
       "url": "/projects/infra_ops/about",
       "description": "The OSS Infra/Ops project provides infrastructure and operations support for open source projects developed at SLU, including shared development environments, infrastructure as code support, instrumentation for observability, and development observability services.",
       "status": "current",
-      "image": "/img/projects/infra_ops.png"
+      "image": "/img/projects/infra_ops.png",
+      "kind": "service",
+      "domain": ["devops"],
+      "research": false
     },
     {
       "name": "Pi4Micronaut",
       "url": "/projects/pi4micronaut/about",
       "description": "Pi4Micronaut is a Java library crafted for developers who aim to build IoT applications leveraging the Raspberry Pi platform.",
       "status": "stable",
-      "image": "/img/projects/pi4micronaut.png"
+      "image": "/img/projects/pi4micronaut.png",
+      "kind": "library",
+      "domain": ["iot"],
+      "research": true
     },
     {
       "name": "Pilot Data Synchronization",
       "url": "/projects/pilot_data_synchronization/about",
       "description": "PDS establishes a real-time data synchronization channel between a flight simulator and the iMotions platform, enabling the accurate capture and analysis of critical flight data to enhance pilot performance evaluation.",
       "status": "current",
-      "image": "/img/projects/pilot_data_synchronization.png"
+      "image": "/img/projects/pilot_data_synchronization.png",
+      "kind": "desktop-app",
+      "domain": ["aerospace"],
+      "research": true
     },
     {
       "name": "Rerum Geolocator",
       "url": "/projects/rerum_geolocator/about",
       "description": "The application enables users to enhance discovery and access to digital resources through geographic visualization and annotation.",
       "status": "stable",
-      "image": "/img/projects/rerum_geolocator.png"
+      "image": "/img/projects/rerum_geolocator.png",
+      "kind": "web-app",
+      "domain": ["geospatial", "data"],
+      "research": true
     },
     {
       "name": "Rerum Playground",
       "url": "/projects/rerum_playground/about",
       "description": "Rerum Playground is a webspace with tools to interact with objects that may exist in RERUM and all over the internet.",
       "status": "current",
-      "image": "/img/projects/rerum_playground.png"
+      "image": "/img/projects/rerum_playground.png",
+      "kind": "web-app",
+      "domain": ["dev-tools", "data"],
+      "research": true
     },
     {
       "name": "Rerum Server",
       "url": "/projects/rerum_server/about",
       "description": "Rerum Server is a Node.js-based API server that provides CRUD operations and IIIF-compliant services for managing linked data objects in the RERUM ecosystem.",
       "status": "current",
-      "image": "/img/projects/default.png"
+      "image": "/img/projects/default.png",
+      "kind": "platform",
+      "domain": ["ai-ml", "data"],
+      "research": true
     },
     {
       "name": "Saltify Speech Transcription",
       "url": "/projects/saltify/about",
       "description": "Saltify Speech Tagging software transcribes an audio sample into a written format that is accepted by SALT software.",
       "status": "current",
-      "image": "/img/projects/saltify.png"
+      "image": "/img/projects/saltify.png",
+      "kind": "web-app",
+      "domain": ["speech-language", "healthcare", "work-management"],
+      "research": true
     },
     {
       "name": "Santiago",
       "url": "https://github.com/oss-slu/Santiago",
       "description": "Desktop app to visualize microscopy of neurons based on a MatLab library.",
       "status": "completed",
-      "image": "/img/projects/santiago.png"
+      "image": "/img/projects/santiago.png",
+      "kind": "desktop-app",
+      "domain": ["life-sciences", "simulation"],
+      "research": true
     },
     {
       "name": "Seeing Is Believing",
       "url": "/projects/sib/about",
       "description": "An educational learning tool enabling visualizing the pronunciation of Spanish words.",
       "status": "completed",
-      "image": "/img/projects/sib.png"
+      "image": "/img/projects/sib.png",
+      "kind": "web-app",
+      "domain": ["education", "speech-language"],
+      "research": false
     },
     {
       "name": "Shelter Volunteers Rapid Response",
       "url": "/projects/shelter_volunteers/about",
       "description": "Simplify the process of scheduling work shifts for volunteers at temporary shelters, and to give homeless shelters visibility into their upcoming staffing.",
       "status": "current",
-      "image": "/img/projects/shelter_volunteers.png"
+      "image": "/img/projects/shelter_volunteers.png",
+      "kind": "web-app",
+      "domain": ["civic", "work-management"],
+      "research": false
     },
     {
       "name": "Simulation Surgery",
       "url": "/projects/simulation_surgery/about",
       "description": "The Simulation Surgery focuses on creating a 3D visualization tool a web based platform to simulate surgical procedures for educational and research purposes.",
       "status": "current",
-      "image": "/img/projects/default.png"
+      "image": "/img/projects/default.png",
+      "kind": "web-app",
+      "domain": ["healthcare", "education", "simulation"],
+      "research": true
     },
     {
       "name": "Step Time Biofeedback",
       "url": "/projects/step_time_biofeedback/about",
       "description": "Step Time Biofeedback is a tool that leverages force signal data from a Bertec split-belt treadmill to calculate step time and project target zones into a biofeedback system.",
       "status": "stable",
-      "image": "/img/projects/step_time_biofeedback.png"
+      "image": "/img/projects/step_time_biofeedback.png",
+      "kind": "desktop-app",
+      "domain": ["healthcare"],
+      "research": true
     },
     {
       "name": "STL Data API",
       "url": "/projects/stl_data_api/about",
       "description": "STL Data API unifies regional public data for analysis, visualization, and policy-making.",
       "status": "stable",
-      "image": "/img/projects/stl_data_api.png"
+      "image": "/img/projects/stl_data_api.png",
+      "kind": "platform",
+      "domain": ["civic", "data"],
+      "research": true
     },
     {
       "name": "TheHealthApp",
       "url": "/projects/health_app/about",
       "description": "TheHealthApp enable basic AI powered health assessments, connects patients with services services, gives patients simple and secure access to their health data.",
       "status": "current",
-      "image": "/img/projects/health_app.png"
+      "image": "/img/projects/health_app.png",
+      "kind": "web-app",
+      "domain": ["healthcare", "ai-ml", "civic"],
+      "research": false
     },
     {
       "name": "TPEN Interfaces",
       "url": "/projects/tpen_interfaces/about",
       "description": "The TPEN Interfaces project provides a set of customizable web interfaces that leverage the TPEN Services API.",
       "status": "stable",
-      "image": "/img/projects/tpeninterfaces.png"
+      "image": "/img/projects/tpeninterfaces.png",
+      "kind": "web-app",
+      "domain": ["digital-humanities"],
+      "research": true
     },
     {
       "name": "Where's Religion Desktop",
       "url": "/projects/wheres_religion_desktop/about",
       "description": "Where's Religion Desktop is a web app for ethnographers of 'Lived Religion' that enables detailed reflection and analysis of events captured with the Where's Religion Mobile app.",
       "status": "current",
-      "image": "/img/projects/wheres_religion_desktop.png"
+      "image": "/img/projects/wheres_religion_desktop.png",
+      "kind": "web-app",
+      "domain": ["digital-humanities", "social-science"],
+      "research": true
     },
     {
       "name": "Where's Religion Mobile",
       "url": "/projects/wheres_religion_mobile/about",
       "description": "Where's Religion Mobile is a mobile app for ethnographers of 'Lived Religion' to capture the events happening around them along with some audio/visual representation of the event.",
       "status": "current",
-      "image": "/img/projects/wheres_religion_mobile.png"
+      "image": "/img/projects/wheres_religion_mobile.png",
+      "kind": "mobile-app",
+      "domain": ["digital-humanities", "social-science"],
+      "research": true
     }
   ]

--- a/src/data/projects/productTypes.js
+++ b/src/data/projects/productTypes.js
@@ -1,0 +1,42 @@
+// Display labels for kind values used in Projects.json.
+// Update this map when new kind values are introduced.
+export const kindLabels = {
+  'web-app': 'Web Applications',
+  'mobile-app': 'Mobile Apps',
+  'desktop-app': 'Desktop Applications',
+  'platform': 'Platforms & APIs',
+  'library': 'Libraries & Toolkits',
+  'cli': 'CLI Tools',
+  'vr': 'VR & Simulation',
+  'service': 'Internal Services',
+  'iot': 'IoT & Devices',
+};
+
+// Display labels for domain values used in Projects.json.
+// Update this map when new domain values are introduced.
+export const domainLabels = {
+  'aerospace': 'Aerospace',
+  'ai-ml': 'AI & Machine Learning',
+  'chemistry': 'Chemistry',
+  'civic': 'Civic & Community',
+  'cybersecurity': 'Cybersecurity',
+  'data': 'Data & Analytics',
+  'dev-tools': 'Developer Tools',
+  'devops': 'DevOps',
+  'digital-humanities': 'Digital Humanities',
+  'education': 'Education',
+  'energy': 'Energy',
+  'entrepreneurship': 'Entrepreneurship',
+  'geospatial': 'Geospatial',
+  'healthcare': 'Healthcare',
+  'iot': 'IoT',
+  'life-sciences': 'Life Sciences',
+  'manufacturing': 'Manufacturing',
+  'mathematics': 'Mathematics',
+  'networking': 'Networking',
+  'robotics': 'Robotics',
+  'simulation': 'Simulation',
+  'social-science': 'Social Science',
+  'speech-language': 'Speech & Language',
+  'work-management': 'Work Management',
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import HomepageFeatures from "@site/src/components/HomepageFeatures";
+import HomepageStats from "@site/src/components/HomepageStats";
 import { Carousel } from 'react-responsive-carousel';
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
 
@@ -76,6 +77,7 @@ export default function Home() {
           </div>
         </div>
 
+        <HomepageStats />
         <HomepageFeatures />
       </main>
     </Layout>


### PR DESCRIPTION
## Summary
- Add dynamic stats header components to the homepage, portfolio, staff, and alumni contributors pages
- Enrich Projects.json with `kind`, `domain` (array), and `research` (boolean) metadata for all 48 projects
- Homepage displays a staggered two-card layout (Projects + Contributors) between the intro section and feature cards
- Portfolio page header shows status breakdown, research count, product types (derived from kind), and domains (derived from domain)
- Staff and alumni pages cross-link to each other via divider stats (Active Now / Alumni)
- Add shared `productTypes.js` with display label maps for kind and domain values
- Add shared `.stats-header` CSS using Infima variables for dark mode support

## Test plan
- [ ] Verify homepage stats render correctly with staggered layout
- [ ] Verify portfolio page shows all stats, product types, and domains
- [ ] Verify staff page header shows current team counts + alumni link
- [ ] Verify alumni contributors page header shows alumni counts + active now link
- [ ] Verify cross-links between staff and alumni pages work
- [ ] Verify responsive behavior at mobile breakpoints (768px, 480px)
- [ ] Verify dark mode renders correctly
- [ ] Run `npm run build` to confirm no broken links or build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)