### PR TITLE
adds github corner tag for project cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@docusaurus/core": "3.10.0",
-        "@docusaurus/plugin-client-redirects": "^3.10.0",
+        "@docusaurus/plugin-client-redirects": "3.10.0",
         "@docusaurus/preset-classic": "3.10.0",
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "3.1.1",

--- a/src/components/projects/ProjectCard.js
+++ b/src/components/projects/ProjectCard.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import '../../css/ProjectsPage.css';  // You will design styles here
 
-export default function ProjectCard({ project }) {
-  const isGithubUrl = project.url?.includes("github.com"); 
-  const githubLink = project.github || (isGithubUrl ? project.url : null);
+export default function ProjectCard({ project }) { 
+  const githubLink = project.github || null;
   return (
     <div className="project-card">
       {githubLink && (

--- a/src/components/projects/ProjectCard.js
+++ b/src/components/projects/ProjectCard.js
@@ -2,8 +2,46 @@ import React from 'react';
 import '../../css/ProjectsPage.css';  // You will design styles here
 
 export default function ProjectCard({ project }) {
+  const isGithubUrl = project.url?.includes("github.com"); 
+  const githubLink = project.github || (isGithubUrl ? project.url : null);
   return (
     <div className="project-card">
+      {githubLink && (
+        <a
+        href={githubLink}
+        className="github-corner"
+        aria-label="View source on GitHub"
+        target="_blank"
+        >
+        <svg
+          width="55"
+          height="55"
+          viewBox="0 0 250 250"
+          style={{
+            fill: '#70B7FD',
+            color: '#fff',
+            position: 'absolute',
+            top: 0,
+            border: 0,
+            right: 0,
+          }}
+          aria-hidden="true"
+        >
+          <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z" />
+          <path
+            d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+            fill="currentColor"
+            style={{ transformOrigin: '130px 106px' }}
+            className="octo-arm"
+          />
+          <path
+            d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+            fill="currentColor"
+            className="octo-body"
+          />
+        </svg>
+      </a>
+      )}
       <a href={project.url} target="_blank" rel="noopener noreferrer">
         {/* Uncomment the below once you have images */}
         {/* <div className="project-card-image">

--- a/src/data/projects/Projects.json
+++ b/src/data/projects/Projects.json
@@ -7,7 +7,8 @@
       "image": "/img/projects/baio.png",
       "kind": "web-app",
       "domain": ["life-sciences", "ai-ml"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/baio"
     },
     {
       "name": "Bubble Scan",
@@ -17,7 +18,8 @@
       "image": "/img/projects/bubblescan.png",
       "kind": "web-app",
       "domain": ["education", "work-management", "ai-ml"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/bubble_scan"
     },
     {
       "name": "CivicKit",
@@ -27,7 +29,8 @@
       "image": "/img/projects/default.png",
       "kind": "library",
       "domain": ["civic", "entrepreneurship"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/civickit"
     },
     {
       "name": "Congestion Control Emulator",
@@ -47,7 +50,8 @@
       "image": "/img/projects/open_project.png",
       "kind": "web-app",
       "domain": ["work-management", "manufacturing", "education"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/core_desk"
     },
     {
       "name": "CV Zebrafish",
@@ -57,7 +61,8 @@
       "image": "/img/projects/cv_zebrafish.png",
       "kind": "web-app",
       "domain": ["life-sciences", "ai-ml", "simulation"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/cv_zebrafish"
     },
     {
       "name": "DADS: Database of Arithmetic Dynamical Systems",
@@ -67,7 +72,8 @@
       "image": "/img/projects/dads.png",
       "kind": "web-app",
       "domain": ["mathematics"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/dads"
     },
     {
       "name": "DEER: Data Entry & Exhibition for Rerum",
@@ -87,7 +93,8 @@
       "image": "/img/projects/digital_bone_box.png",
       "kind": "web-app",
       "domain": ["education", "healthcare"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/DigitalBonesBox"
     },
     {
       "name": "Drone World",
@@ -97,7 +104,8 @@
       "image": "/img/projects/droneworld.png",
       "kind": "platform",
       "domain": ["aerospace", "simulation"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/DroneWorld"
     },
     {
       "name": "DroneSwarm",
@@ -117,7 +125,8 @@
       "image": "/img/projects/esp.png",
       "kind": "web-app",
       "domain": ["life-sciences", "chemistry"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/esp"
     },
     {
       "name": "Gallery of Glosses",
@@ -137,7 +146,8 @@
       "image": "/img/projects/default.png",
       "kind": "web-app",
       "domain": ["education", "work-management"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/GradEval360"
     },
     {
       "name": "HPC Projects",
@@ -167,7 +177,8 @@
       "image": "/img/projects/default.png",
       "kind": "cli",
       "domain": ["networking"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/iperf"
     },
     {
       "name": "IRIS: Image Recognition Integration System",
@@ -177,7 +188,8 @@
       "image": "/img/projects/iris.png",
       "kind": "library",
       "domain": ["healthcare", "ai-ml"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/image-recognition-integration-system"
     },
     {
       "name": "iSpraak",
@@ -197,7 +209,8 @@
       "image": "/img/projects/md.png",
       "kind": "web-app",
       "domain": ["civic", "work-management"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/material-derailleur"
     },
     {
       "name": "MechatronicsVR",
@@ -207,7 +220,8 @@
       "image": "/img/projects/vr_robotics.png",
       "kind": "vr",
       "domain": ["education", "robotics", "simulation"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/mechatronics-vr"
     },
     {
       "name": "MeltShiny",
@@ -217,7 +231,8 @@
       "image": "/img/projects/meltshiny.png",
       "kind": "web-app",
       "domain": ["life-sciences", "chemistry"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/MeltShiny"
     },
     {
       "name": "Mithridatium",
@@ -227,7 +242,8 @@
       "image": "/img/projects/mithridatium.png",
       "kind": "platform",
       "domain": ["cybersecurity", "ai-ml", "dev-tools"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/mithridatium"
     },
     {
       "name": "ML Code Generator",
@@ -247,7 +263,8 @@
       "image": "/img/projects/default.png",
       "kind": "web-app",
       "domain": ["geospatial", "education", "civic", "entrepreneurship"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/montis"
     },
     {
       "name": "MORPH",
@@ -257,7 +274,8 @@
       "image": "/img/projects/smartrobot.png",
       "kind": "platform",
       "domain": ["education", "robotics", "entrepreneurship"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/MORPH"
     },
     {
       "name": "Mouser",
@@ -267,7 +285,8 @@
       "image": "/img/projects/mouser.png",
       "kind": "desktop-app",
       "domain": ["life-sciences", "work-management"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/mouser"
     },
     {
       "name": "Open Energy Dashboard",
@@ -277,7 +296,8 @@
       "image": "/img/projects/open_energy_dashboard.png",
       "kind": "web-app",
       "domain": ["energy", "work-management"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/OED"
     },
     {
       "name": "OSS CI/CD & Automation",
@@ -287,7 +307,8 @@
       "image": "/img/projects/cicd_automation.png",
       "kind": "service",
       "domain": ["devops"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/oss_cicd_automation"
     },
     {
       "name": "OSS Cybersecurity",
@@ -297,7 +318,8 @@
       "image": "/img/projects/default.png",
       "kind": "service",
       "domain": ["devops", "cybersecurity"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/oss_cybersecurity"
     },
     {
       "name": "OSS Dev Analytics",
@@ -307,7 +329,8 @@
       "image": "/img/projects/dev_analytics.png",
       "kind": "service",
       "domain": ["devops", "data"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/oss_dev_analytics"
     },
     {
       "name": "OSS Infra/Ops",
@@ -317,7 +340,8 @@
       "image": "/img/projects/infra_ops.png",
       "kind": "service",
       "domain": ["devops"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/oss_infra_ops"
     },
     {
       "name": "Pi4Micronaut",
@@ -327,7 +351,8 @@
       "image": "/img/projects/pi4micronaut.png",
       "kind": "library",
       "domain": ["iot"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/Pi4Micronaut"
     },
     {
       "name": "Pilot Data Synchronization",
@@ -337,7 +362,8 @@
       "image": "/img/projects/pilot_data_synchronization.png",
       "kind": "desktop-app",
       "domain": ["aerospace"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/PilotDataSynchronization"
     },
     {
       "name": "Rerum Geolocator",
@@ -357,7 +383,8 @@
       "image": "/img/projects/rerum_playground.png",
       "kind": "web-app",
       "domain": ["dev-tools", "data"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/rerum-playground"
     },
     {
       "name": "Rerum Server",
@@ -367,7 +394,8 @@
       "image": "/img/projects/default.png",
       "kind": "platform",
       "domain": ["ai-ml", "data"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/rerum_server_nodejs"
     },
     {
       "name": "Saltify Speech Transcription",
@@ -377,7 +405,8 @@
       "image": "/img/projects/saltify.png",
       "kind": "web-app",
       "domain": ["speech-language", "healthcare", "work-management"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/SpeechTranscription"
     },
     {
       "name": "Santiago",
@@ -387,7 +416,8 @@
       "image": "/img/projects/santiago.png",
       "kind": "desktop-app",
       "domain": ["life-sciences", "simulation"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/Santiago"
     },
     {
       "name": "Seeing Is Believing",
@@ -397,7 +427,8 @@
       "image": "/img/projects/sib.png",
       "kind": "web-app",
       "domain": ["education", "speech-language"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/Seeing-is-Believing"
     },
     {
       "name": "Shelter Volunteers Rapid Response",
@@ -407,7 +438,8 @@
       "image": "/img/projects/shelter_volunteers.png",
       "kind": "web-app",
       "domain": ["civic", "work-management"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/shelter_volunteers"
     },
     {
       "name": "Simulation Surgery",
@@ -417,7 +449,8 @@
       "image": "/img/projects/default.png",
       "kind": "web-app",
       "domain": ["healthcare", "education", "simulation"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/pao_surgery_simulator"
     },
     {
       "name": "Step Time Biofeedback",
@@ -427,7 +460,8 @@
       "image": "/img/projects/step_time_biofeedback.png",
       "kind": "desktop-app",
       "domain": ["healthcare"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/Step_Time_Biofeedback"
     },
     {
       "name": "STL Data API",
@@ -437,7 +471,8 @@
       "image": "/img/projects/stl_data_api.png",
       "kind": "platform",
       "domain": ["civic", "data"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/stl_metro_data_api"
     },
     {
       "name": "TheHealthApp",
@@ -447,7 +482,8 @@
       "image": "/img/projects/health_app.png",
       "kind": "web-app",
       "domain": ["healthcare", "ai-ml", "civic"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/TheHealthApp"
     },
     {
       "name": "TPEN Interfaces",
@@ -457,7 +493,8 @@
       "image": "/img/projects/tpeninterfaces.png",
       "kind": "web-app",
       "domain": ["digital-humanities"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/TPEN-interfaces"
     },
     {
       "name": "Where's Religion Desktop",
@@ -477,6 +514,7 @@
       "image": "/img/projects/wheres_religion_mobile.png",
       "kind": "mobile-app",
       "domain": ["digital-humanities", "social-science"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/lrda_mobile"
     }
   ]

--- a/src/data/projects/Projects.json
+++ b/src/data/projects/Projects.json
@@ -40,7 +40,8 @@
       "image": "/img/projects/congestion_control_emulator.png",
       "kind": "cli",
       "domain": ["networking"],
-      "research": true
+      "research": true,
+      "github": "https://github.com/oss-slu/Congestion-control-emulator"
     },
     {
       "name": "CoreDesk",
@@ -253,7 +254,8 @@
       "image": "/img/projects/ml_code_generator.png",
       "kind": "web-app",
       "domain": ["ai-ml", "education"],
-      "research": false
+      "research": false,
+      "github": "https://github.com/oss-slu/ml_code_generator"
     },
     {
       "name": "Montis Peaks 3D",


### PR DESCRIPTION
> small cat sits in a corner wagging its tail to take us to a place where software is built. 

Summary : 
* Adds GitHub Corner ribbon links to all project portfolio pages and project cards, giving users direct, immediate access to each project's source code repository.
* SVG from https://tholman.com/github-corners/
* github field with URL is added to projects.json to dynamically link to repository.
*  Ribbon only exists for repos that are in oss-slu org. It doesnt appear for following repos :
    * DEER: Data Entry & Exhibition for Rerum, IRDA Desktop, Rerum Geolocator, Inner Peace, HPC, ISpraak, Gallery of Glosses, Drone Swarm