### PR TITLE
Fix vertical alignment on homepage metrics cards

### DIFF
--- a/src/components/HomepageStats/styles.module.css
+++ b/src/components/HomepageStats/styles.module.css
@@ -32,7 +32,6 @@
 .contributorsCard {
   flex: 1 1 300px;
   min-width: 260px;
-  margin-top: 1.5rem;
 }
 
 .cardTitle {


### PR DESCRIPTION
## Summary
- Removes an extra `margin-top: 1.5rem` on `.contributorsCard` that was pushing the contributors stats card out of vertical alignment with the other metrics cards on the homepage.

## Test plan
- [x] Verify the three stats cards on the homepage are vertically aligned on the same row
- [x] Check responsive behavior at smaller viewports (cards should still stack properly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)