### PR TITLE
Move Yash Kamal Bhatia to previous staff

### DIFF
--- a/src/data/people/currentStaff.json
+++ b/src/data/people/currentStaff.json
@@ -4,11 +4,5 @@
         "image": "",
         "profileLink": "https://github.com/jacksayshi",
         "bio":"Santosh is a software engineer working on the OSS across SLU project. He also contributes to developing the main OSS website and mentors new tech leads and developers."
-    },
-    {
-        "name": "Yash Kamal Bhatia",
-        "image": "/img/yash_avatar1.jpg",
-        "profileLink": "https://yashb196.github.io/yashb196/",
-        "bio":"Yash is a graduate from SLU who is currently working at the Center of Lived Religion for the Where’s Religion Project. He also supports Open Source with SLU as a software engineer on strategic initiatives."
     }
 ]

--- a/src/data/people/prevStaff.json
+++ b/src/data/people/prevStaff.json
@@ -13,5 +13,10 @@
         "name": "Chintak Joshi",
         "image": "/img/chintak_avatar1.JPG",
         "profileLink": "https://github.com/chintakjoshi"
+    },
+    {
+        "name": "Yash Kamal Bhatia",
+        "image": "/img/yash_avatar1.jpg",
+        "profileLink": "https://yashb196.github.io/yashb196/"
     }
 ]


### PR DESCRIPTION
## Summary
- Removes Yash Kamal Bhatia from `currentStaff.json` and adds him to `prevStaff.json`

## Test plan
- [ ] Verify Yash appears under Previous Staff on the People page
- [ ] Verify he no longer appears under Current Staff

🤖 Generated with [Claude Code](https://claude.com/claude-code)