### PR TITLE
baseline devsecops page refresh

### DIFF
--- a/docs/projects/oss_cicd_automation/about.md
+++ b/docs/projects/oss_cicd_automation/about.md
@@ -15,10 +15,11 @@ The OSS CI/CD & Automation team provides continuous integration and continuous d
 - **Platforms:** Internal Developer Services
 - **Client:** Open Source with SLU
 - **Track:** Internal Developer Services
-- **Current Tech Lead:** Henry Wang [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/ImJustHenry)
+- **Current Tech Lead:** Ahmed Bektic [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/ahmedbektic)
 - **Developers:**
-  - Justin Duong (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/justinduong5)
-  - Thomas Pautler (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/ThomasPautler952194)
+  - Henry Wang (alumni, prior tech lead) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/ImJustHenry)
+  - Justin Duong (alumni) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/justinduong5)
+  - Thomas Pautler (alumni) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/ThomasPautler952194)
   - Srinivasa Varma Penmetsa (alumni, prior tech lead) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/SrinivasaVarmaP)
   - Mehul Antony (alumni) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/Mehulantony)
 - **Start Date:** August 2025

--- a/docs/projects/oss_cybersecurity/about.md
+++ b/docs/projects/oss_cybersecurity/about.md
@@ -13,12 +13,13 @@ The OSS Cybersecurity team is the security and compliance arm of Open Source wit
 - **Source Code:** [https://github.com/oss-slu/oss_cybersecurity](https://github.com/oss-slu/oss_cybersecurity) [<img src="/img/git-alt.svg" alt="git" width="25" height="25" />](https://github.com/oss-slu/oss_cybersecurity)
 - **Status:** Active (and ongoing)
 - **Platforms:** Internal Developer Services
-- **Client:** Open Source with SLU
+- **Client:** Samuel Kann [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/dracpak)
 - **Track:** Internal Developer Services
-- **Current Tech Lead:** Samuel Kann [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/dracpak)
+- **Current Tech Lead:** Ahmed Bektic [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/ahmedbektic)
 - **Developers:**
+  - Samuel Kann (tech lead) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/dracpak)
   - Annie Henehan (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/ahenehan2)
-  - Dennis Sheynkerman (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/dennisshey)
+  - Dennis Sheynkerman (alumni) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/dennisshey)
   - Roemen Edwards (alumni) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/r0me777)
 - **Start Date:** August 2025
 - **Technologies Used:**

--- a/docs/projects/oss_infra_ops/about.md
+++ b/docs/projects/oss_infra_ops/about.md
@@ -17,10 +17,11 @@ The OSS Infra/Ops team provides infrastructure and operations support for open s
 - **Platforms:** Internal Developer Services
 - **Client:** Open Source with SLU
 - **Track:** Internal Developer Services
-- **Current Tech Lead:** Daniel Awodeyi [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/AyoAwodeyi)
+- **Current Tech Lead:** Ahmed Bektic [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/ahmedbektic)
 - **Developers:**
+  - Daniel Awodeyi (alumni, prior tech lead) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/AyoAwodeyi)
   - Hunter Cataldo (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/HuntC19)
-  - Joey Heitzler (capstone) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/j-heitz)
+  - Joey Heitzler (alumni) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/j-heitz)
   - Ava Enke (alumni) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/sudoava)
   - Daniel Shown (project staff) [<img src="/img/github.svg" alt="github" width="25" height="25" />](https://github.com/kungfuchicken) [<img src="/img/linkedin.svg" alt="linkedin" width="25" height="25" />](https://www.linkedin.com/in/daniel.shown/)
 - **Start Date:** August 2025

--- a/src/data/projects/Projects.json
+++ b/src/data/projects/Projects.json
@@ -303,7 +303,7 @@
     },
     {
       "name": "OSS CI/CD & Automation",
-      "url": "/projects/cicd_automation/about",
+      "url": "/projects/oss_cicd_automation/about",
       "description": "OSS CI/CD & Automation project provides continuous integration and continuous deployment (CI/CD) services to open source projects developed at SLU, including automated testing, deployment pipelines, and release management.",
       "status": "current",
       "image": "/img/projects/cicd_automation.png",
@@ -325,7 +325,7 @@
     },
     {
       "name": "OSS Dev Analytics",
-      "url": "/projects/dev_analytics/about",
+      "url": "/projects/oss_dev_analytics/about",
       "description": "OSS Dev Analytics project provides developer analytics and general data analytics support to open source projects developed at SLU.",
       "status": "current",
       "image": "/img/projects/dev_analytics.png",
@@ -336,7 +336,7 @@
     },
     {
       "name": "OSS Infra/Ops",
-      "url": "/projects/infra_ops/about",
+      "url": "/projects/oss_infra_ops/about",
       "description": "The OSS Infra/Ops project provides infrastructure and operations support for open source projects developed at SLU, including shared development environments, infrastructure as code support, instrumentation for observability, and development observability services.",
       "status": "current",
       "image": "/img/projects/infra_ops.png",


### PR DESCRIPTION
1) Refresh DevSecOps project about pages (cybersecurity, CI/CD, infra/ops)

2) Fix portfolio card URLs that pointed at missing routes